### PR TITLE
[BUGFIX] Do not check `Configuration` and `Tests` for duplicate code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,7 @@
 			"@ci:php:sniff",
 			"@ci:php:stan"
 		],
-		"ci:php:copypaste": "phpcpd Classes Configuration Tests",
+		"ci:php:copypaste": "phpcpd Classes",
 		"ci:php:cs-fixer": "php-cs-fixer fix --config .php-cs-fixer.php -v --dry-run --using-cache no --diff",
 		"ci:php:lint": "find *.php Classes Configuration Tests -name '*.php' -print0 | xargs -r -0 -n 1 -P 4 php -l",
 		"ci:php:sniff": "phpcs Classes Configuration Tests",


### PR DESCRIPTION
In those directories, duplicate code is to be expected, and it is
perfectly fine there.