### PR TITLE
[BUGFIX] Initialize all associations even without the constructor

### DIFF
--- a/Classes/Domain/Model/FrontendUser.php
+++ b/Classes/Domain/Model/FrontendUser.php
@@ -114,6 +114,14 @@ class FrontendUser extends AbstractEntity
         $this->usergroup = new ObjectStorage();
     }
 
+    /**
+     * Properly initializes all associations (as fetching an entity from the DB does not use the constructor).
+     */
+    public function initializeObject(): void
+    {
+        $this->usergroup = new ObjectStorage();
+    }
+
     public function getUsername(): string
     {
         return $this->username;

--- a/Classes/Domain/Model/FrontendUserGroup.php
+++ b/Classes/Domain/Model/FrontendUserGroup.php
@@ -38,6 +38,14 @@ class FrontendUserGroup extends AbstractEntity
         $this->subgroup = new ObjectStorage();
     }
 
+    /**
+     * Properly initializes all associations (as fetching an entity from the DB does not use the constructor).
+     */
+    public function initializeObject(): void
+    {
+        $this->subgroup = new ObjectStorage();
+    }
+
     public function getTitle(): string
     {
         return $this->title;

--- a/Tests/Functional/Domain/Repository/FrontendUserGroupRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/FrontendUserGroupRepositoryTest.php
@@ -8,6 +8,7 @@ use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUserGroup;
 use OliverKlee\FeUserExtraFields\Domain\Repository\FrontendUserGroupRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 /**
@@ -61,6 +62,21 @@ final class FrontendUserGroupRepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function initializesSubGroupsWithEmptyStorage(): void
+    {
+        $this->importDataSet(__DIR__ . '/Fixtures/UserGroupWithAllScalarData.xml');
+
+        $model = $this->subject->findByUid(1);
+        self::assertInstanceOf(FrontendUserGroup::class, $model);
+
+        $groups = $model->getSubgroup();
+        self::assertInstanceOf(ObjectStorage::class, $groups);
+        self::assertCount(0, $groups);
+    }
+
+    /**
+     * @test
+     */
     public function mapsSubgroupAssociation(): void
     {
         $this->importDataSet(__DIR__ . '/Fixtures/UserGroupWithTwoSubgroups.xml');
@@ -69,6 +85,7 @@ final class FrontendUserGroupRepositoryTest extends FunctionalTestCase
         self::assertInstanceOf(FrontendUserGroup::class, $model);
 
         $groups = $model->getSubgroup();
+        self::assertInstanceOf(ObjectStorage::class, $groups);
         self::assertCount(2, $groups);
         $groupsAsArray = $groups->toArray();
         self::assertInstanceOf(FrontendUserGroup::class, $groupsAsArray[0]);

--- a/Tests/Functional/Domain/Repository/FrontendUserRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/FrontendUserRepositoryTest.php
@@ -9,6 +9,7 @@ use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUserGroup;
 use OliverKlee\FeUserExtraFields\Domain\Repository\FrontendUserRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 /**
@@ -77,6 +78,21 @@ final class FrontendUserRepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function initializesUserGroupsWithEmptyStorage(): void
+    {
+        $this->importDataSet(__DIR__ . '/Fixtures/UserWithAllScalarData.xml');
+
+        $model = $this->subject->findByUid(1);
+        self::assertInstanceOf(FrontendUser::class, $model);
+
+        $groups = $model->getUsergroup();
+        self::assertInstanceOf(ObjectStorage::class, $groups);
+        self::assertCount(0, $groups);
+    }
+
+    /**
+     * @test
+     */
     public function mapsUserGroupsAssociation(): void
     {
         $this->importDataSet(__DIR__ . '/Fixtures/UserWithTwoGroups.xml');
@@ -85,6 +101,7 @@ final class FrontendUserRepositoryTest extends FunctionalTestCase
         self::assertInstanceOf(FrontendUser::class, $model);
 
         $groups = $model->getUsergroup();
+        self::assertInstanceOf(ObjectStorage::class, $groups);
         self::assertCount(2, $groups);
         $groupsAsArray = $groups->toArray();
         self::assertInstanceOf(FrontendUserGroup::class, $groupsAsArray[0]);


### PR DESCRIPTION
If an entity is read from the DB, the constructor is not called. So we
need to use `initializeObject` to initialize the associations properly.