### PR TITLE
[CLEANUP] Polish the casing of some fields

### DIFF
--- a/Classes/Domain/Model/FrontendUser.php
+++ b/Classes/Domain/Model/FrontendUser.php
@@ -88,7 +88,7 @@ class FrontendUser extends AbstractEntity
     /**
      * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\OliverKlee\FeUserExtraFields\Domain\Model\FrontendUserGroup>
      */
-    protected $usergroup;
+    protected $userGroup;
 
     /**
      * @var string
@@ -173,7 +173,7 @@ class FrontendUser extends AbstractEntity
     /**
      * @var \DateTime|null
      */
-    protected $lastlogin;
+    protected $lastLogin;
 
     /**
      * @var int
@@ -204,7 +204,7 @@ class FrontendUser extends AbstractEntity
     {
         $this->username = $username;
         $this->password = $password;
-        $this->usergroup = new ObjectStorage();
+        $this->userGroup = new ObjectStorage();
         $this->image = new ObjectStorage();
     }
 
@@ -213,7 +213,7 @@ class FrontendUser extends AbstractEntity
      */
     public function initializeObject(): void
     {
-        $this->usergroup = new ObjectStorage();
+        $this->userGroup = new ObjectStorage();
         $this->image = new ObjectStorage();
     }
 
@@ -243,9 +243,9 @@ class FrontendUser extends AbstractEntity
      *
      * @return ObjectStorage<FrontendUserGroup>
      */
-    public function getUsergroup(): ObjectStorage
+    public function getUserGroup(): ObjectStorage
     {
-        return $this->usergroup;
+        return $this->userGroup;
     }
 
     /**
@@ -254,19 +254,19 @@ class FrontendUser extends AbstractEntity
      *
      * @param ObjectStorage<FrontendUserGroup> $groups
      */
-    public function setUsergroup(ObjectStorage $groups): void
+    public function setUserGroup(ObjectStorage $groups): void
     {
-        $this->usergroup = $groups;
+        $this->userGroup = $groups;
     }
 
-    public function addUsergroup(FrontendUserGroup $group): void
+    public function addUserGroup(FrontendUserGroup $group): void
     {
-        $this->usergroup->attach($group);
+        $this->userGroup->attach($group);
     }
 
-    public function removeUsergroup(FrontendUserGroup $group): void
+    public function removeUserGroup(FrontendUserGroup $group): void
     {
-        $this->usergroup->detach($group);
+        $this->userGroup->detach($group);
     }
 
     public function getName(): string
@@ -439,14 +439,14 @@ class FrontendUser extends AbstractEntity
         $this->image = $images;
     }
 
-    public function getLastlogin(): ?\DateTime
+    public function getLastLogin(): ?\DateTime
     {
-        return $this->lastlogin;
+        return $this->lastLogin;
     }
 
-    public function setLastlogin(\DateTime $lastlogin): void
+    public function setLastLogin(\DateTime $lastLogin): void
     {
-        $this->lastlogin = $lastlogin;
+        $this->lastLogin = $lastLogin;
     }
 
     public function getZone(): string

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -6,7 +6,9 @@ return [
     OliverKlee\FeUserExtraFields\Domain\Model\FrontendUser::class => [
         'tableName' => 'fe_users',
         'properties' => [
+            'userGroup' => ['fieldName' => 'usergroup'],
             'lockToDomain' => ['fieldName' => 'lockToDomain'],
+            'lastLogin' => ['fieldName' => 'lastlogin'],
         ],
     ],
     OliverKlee\FeUserExtraFields\Domain\Model\FrontendUserGroup::class => [

--- a/Tests/Functional/Domain/Repository/FrontendUserRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/FrontendUserRepositoryTest.php
@@ -73,7 +73,7 @@ final class FrontendUserRepositoryTest extends FunctionalTestCase
         self::assertSame('United States of CAT', $model->getCountry());
         self::assertSame('www.example.com', $model->getWww());
         self::assertSame('Cat Scans Inc.', $model->getCompany());
-        self::assertEquals(new \DateTime('2022-04-02T18:00'), $model->getLastlogin());
+        self::assertEquals(new \DateTime('2022-04-02T18:00'), $model->getLastLogin());
         self::assertSame('NRW', $model->getZone());
         self::assertSame(FrontendUser::GENDER_FEMALE, $model->getGender());
         self::assertEquals(new \DateTime('2022-04-02T00:00'), $model->getDateOfBirth());
@@ -91,7 +91,7 @@ final class FrontendUserRepositoryTest extends FunctionalTestCase
         $model = $this->subject->findByUid(1);
         self::assertInstanceOf(FrontendUser::class, $model);
 
-        $groups = $model->getUsergroup();
+        $groups = $model->getUserGroup();
         self::assertInstanceOf(ObjectStorage::class, $groups);
         self::assertCount(0, $groups);
     }
@@ -106,7 +106,7 @@ final class FrontendUserRepositoryTest extends FunctionalTestCase
         $model = $this->subject->findByUid(1);
         self::assertInstanceOf(FrontendUser::class, $model);
 
-        $groups = $model->getUsergroup();
+        $groups = $model->getUserGroup();
         self::assertInstanceOf(ObjectStorage::class, $groups);
         self::assertCount(2, $groups);
         $groupsAsArray = $groups->toArray();

--- a/Tests/Unit/Domain/Model/FrontendUserTest.php
+++ b/Tests/Unit/Domain/Model/FrontendUserTest.php
@@ -85,9 +85,9 @@ final class FrontendUserTest extends UnitTestCase
     /**
      * @test
      */
-    public function getUsergroupInitiallyReturnsEmptyStorage(): void
+    public function getUserGroupInitiallyReturnsEmptyStorage(): void
     {
-        $result = $this->subject->getUsergroup();
+        $result = $this->subject->getUserGroup();
 
         self::assertInstanceOf(ObjectStorage::class, $result);
         self::assertCount(0, $result);
@@ -96,41 +96,41 @@ final class FrontendUserTest extends UnitTestCase
     /**
      * @test
      */
-    public function setUsergroupSetsUserGroups(): void
+    public function setUserGroupSetsUserGroups(): void
     {
         /** @var ObjectStorage<FrontendUserGroup> $groups */
         $groups = new ObjectStorage();
         $groups->attach(new FrontendUserGroup('foo'));
 
-        $this->subject->setUsergroup($groups);
+        $this->subject->setUserGroup($groups);
 
-        self::assertSame($groups, $this->subject->getUsergroup());
+        self::assertSame($groups, $this->subject->getUserGroup());
     }
 
     /**
      * @test
      */
-    public function addUsergroupAddsUserGroup(): void
+    public function addUserGroupAddsUserGroup(): void
     {
         $group = new FrontendUserGroup('foo');
 
-        $this->subject->addUsergroup($group);
+        $this->subject->addUserGroup($group);
 
-        self::assertTrue($this->subject->getUsergroup()->contains($group));
+        self::assertTrue($this->subject->getUserGroup()->contains($group));
     }
 
     /**
      * @test
      */
-    public function removeUsergroupRemovesUserGroup(): void
+    public function removeUserGroupRemovesUserGroup(): void
     {
         $group = new FrontendUserGroup('foo');
-        $this->subject->addUsergroup($group);
-        self::assertTrue($this->subject->getUsergroup()->contains($group));
+        $this->subject->addUserGroup($group);
+        self::assertTrue($this->subject->getUserGroup()->contains($group));
 
-        $this->subject->removeUsergroup($group);
+        $this->subject->removeUserGroup($group);
 
-        self::assertFalse($this->subject->getUsergroup()->contains($group));
+        self::assertFalse($this->subject->getUserGroup()->contains($group));
     }
 
     /**
@@ -490,9 +490,9 @@ final class FrontendUserTest extends UnitTestCase
     /**
      * @test
      */
-    public function getLastloginInitiallyReturnsNull(): void
+    public function getLastLoginInitiallyReturnsNull(): void
     {
-        $result = $this->subject->getLastlogin();
+        $result = $this->subject->getLastLogin();
 
         self::assertNull($result);
     }
@@ -500,13 +500,13 @@ final class FrontendUserTest extends UnitTestCase
     /**
      * @test
      */
-    public function setLastloginSetsLastlogin(): void
+    public function setLastLoginSetsLastLogin(): void
     {
         $date = new \DateTime();
 
-        $this->subject->setLastlogin($date);
+        $this->subject->setLastLogin($date);
 
-        self::assertSame($date, $this->subject->getLastlogin());
+        self::assertSame($date, $this->subject->getLastLogin());
     }
 
     /**

--- a/ext_typoscript_setup.txt
+++ b/ext_typoscript_setup.txt
@@ -4,7 +4,9 @@ config.tx_extbase.persistence.classes {
         mapping {
             tableName = fe_users
             columns {
+                usergroup.mapOnProperty = userGroup
                 lockToDomain.mapOnProperty = lockToDomain
+                lastlogin.mapOnProperty = lastLogin
             }
         }
     }


### PR DESCRIPTION
We cannot (easily) change the names of the DB columns, but at least
we can polish the field names and corresponding getters and setters.
As method and field names in PHP are case-insensitive, this is not
breaking.

Fixes #27