### PR TITLE
[BUGFIX] Use Composer 2.2 for the unit and functional tests an CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
-          tools: composer:v2.3
+          tools: composer:v2.2
       - name: "Show Composer version"
         run: composer --version
       - name: "Cache dependencies installed with composer"
@@ -166,7 +166,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
-          tools: composer:v2.3
+          tools: composer:v2.2
           extensions: mysqli
           coverage: none
       - name: "Show Composer version"


### PR DESCRIPTION
This fixes a breakage with TYPO3 V9.