### PR TITLE
[BUGFIX] Allow more versions of PHPCov

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 		"phpstan/extension-installer": "^1.1.0",
 		"phpstan/phpstan": "^1.5.2",
 		"phpstan/phpstan-phpunit": "^1.1.0",
-		"phpunit/phpcov": "^6.0.1",
+		"phpunit/phpcov": "^5.0.0 || ^6.0.1",
 		"phpunit/phpunit": "^7.5.20 || ^8.5.25",
 		"saschaegerer/phpstan-typo3": "^1.1.2",
 		"sebastian/phpcpd": "^4.1.0",


### PR DESCRIPTION
This allows Composer installation with PHPUnit 7 again.