### PR TITLE
[CLEANUP] Reuse `initializeObject` from the constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- Reuse `initializeObject` from the constructor (#54)
 - Switch the code coverage collection to Coveralls (#53)
 
 ### Deprecated

--- a/Classes/Domain/Model/FrontendUser.php
+++ b/Classes/Domain/Model/FrontendUser.php
@@ -218,8 +218,7 @@ class FrontendUser extends AbstractEntity
     {
         $this->username = $username;
         $this->password = $password;
-        $this->userGroup = new ObjectStorage();
-        $this->image = new ObjectStorage();
+        $this->initializeObject();
     }
 
     /**

--- a/Classes/Domain/Model/FrontendUserGroup.php
+++ b/Classes/Domain/Model/FrontendUserGroup.php
@@ -35,7 +35,7 @@ class FrontendUserGroup extends AbstractEntity
     public function __construct(string $title = '')
     {
         $this->setTitle($title);
-        $this->subgroup = new ObjectStorage();
+        $this->initializeObject();
     }
 
     /**


### PR DESCRIPTION
This also reduces code duplication.