### PR TITLE
[TASK] Run unit tests before functional tests for coverage

### DIFF
--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -45,6 +45,8 @@ jobs:
           composer show
       - name: "Start MySQL"
         run: "sudo /etc/init.d/mysql start"
+      - name: "Run unit tests with coverage"
+        run: composer ci:coverage:unit
       - name: "Run functional tests with coverage"
         run: |
           export typo3DatabaseName="typo3";
@@ -52,8 +54,6 @@ jobs:
           export typo3DatabaseUsername="root";
           export typo3DatabasePassword="root";
           composer ci:coverage:functional
-      - name: "Run unit tests with coverage"
-        run: composer ci:coverage:unit
       - name: "Merge coverage results"
         run: composer ci:coverage:merge
       - name: "Upload coverage results to Coveralls"


### PR DESCRIPTION
We generally should run the faster tests first so that any possible
breakage occurs as soon as possible, hence providing faster feedback.