### PR TITLE
[BUGFIX] Explicitly require Prophecy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
 		"ergebnis/composer-normalize": "^2.19.0",
 		"friendsofphp/php-cs-fixer": "^3.4.0",
 		"jangregor/phpstan-prophecy": "^1.0.0",
+		"phpspec/prophecy": "^1.15.0",
 		"phpstan/extension-installer": "^1.1.0",
 		"phpstan/phpstan": "^1.6.3",
 		"phpstan/phpstan-phpunit": "^1.1.1",


### PR DESCRIPTION
PHPUnit has dropped its dependency on Prophecy. In order to keep using
Prophecy in our tests, we need to add it as an explicit (development)
dependency.

Also, relying on transitive dependencies is bad practice anyway.