### PR TITLE
[BUGFIX] Git-ignore the `tools/` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@
 /composer.lock
 /coverage
 /nbproject
+/tools
 /var


### PR DESCRIPTION
As this directory was introduced (and git-ignored) in the current development
branch, ignoring it in all active branches makes switching between branches
less of a hassle.