### PR TITLE
[TASK] Drop the `lockToDomain` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Deprecated
 
 ### Removed
+- Drop the `locktodomain` property (#146)
 
 ### Fixed
 

--- a/Classes/Domain/Model/FrontendUser.php
+++ b/Classes/Domain/Model/FrontendUser.php
@@ -145,12 +145,6 @@ class FrontendUser extends AbstractEntity
 
     /**
      * @var string
-     * @Extbase\Validate("StringLength", options={"maximum": 50})
-     */
-    protected $lockToDomain = '';
-
-    /**
-     * @var string
      * @Extbase\Validate("StringLength", options={"maximum": 40})
      */
     protected $title = '';
@@ -391,16 +385,6 @@ class FrontendUser extends AbstractEntity
     public function setEmail(string $email): void
     {
         $this->email = $email;
-    }
-
-    public function getLockToDomain(): string
-    {
-        return $this->lockToDomain;
-    }
-
-    public function setLockToDomain(string $lockToDomain): void
-    {
-        $this->lockToDomain = $lockToDomain;
     }
 
     public function getTitle(): string

--- a/Classes/Domain/Model/FrontendUserGroup.php
+++ b/Classes/Domain/Model/FrontendUserGroup.php
@@ -21,12 +21,6 @@ class FrontendUserGroup extends AbstractEntity
 
     /**
      * @var string
-     * @Extbase\Validate("StringLength", options={"maximum": 50})
-     */
-    protected $lockToDomain = '';
-
-    /**
-     * @var string
      * @Extbase\Validate("StringLength", options={"maximum": 65535})
      */
     protected $description = '';
@@ -58,16 +52,6 @@ class FrontendUserGroup extends AbstractEntity
     public function setTitle(string $title): void
     {
         $this->title = $title;
-    }
-
-    public function getLockToDomain(): string
-    {
-        return $this->lockToDomain;
-    }
-
-    public function setLockToDomain(string $lockToDomain): void
-    {
-        $this->lockToDomain = $lockToDomain;
     }
 
     public function getDescription(): string

--- a/Tests/Functional/Domain/Repository/Fixtures/UserGroupWithAllScalarData.xml
+++ b/Tests/Functional/Domain/Repository/Fixtures/UserGroupWithAllScalarData.xml
@@ -3,7 +3,6 @@
     <fe_groups>
         <uid>1</uid>
         <title>editors</title>
-        <lockToDomain>www.example.com</lockToDomain>
         <description>We build websites!</description>
     </fe_groups>
 </dataset>

--- a/Tests/Functional/Domain/Repository/Fixtures/UserWithAllScalarData.xml
+++ b/Tests/Functional/Domain/Repository/Fixtures/UserWithAllScalarData.xml
@@ -13,7 +13,6 @@
         <telephone>+49 1111 1233456-78</telephone>
         <fax>+49 1111 1233456-79</fax>
         <email>max@example.com</email>
-        <lockToDomain>example.com</lockToDomain>
         <title>Head of fur</title>
         <zip>01234</zip>
         <city>Kattingen</city>

--- a/Tests/Functional/Domain/Repository/FrontendUserGroupRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/FrontendUserGroupRepositoryTest.php
@@ -53,7 +53,6 @@ final class FrontendUserGroupRepositoryTest extends FunctionalTestCase
 
         self::assertInstanceOf(FrontendUserGroup::class, $model);
         self::assertSame('editors', $model->getTitle());
-        self::assertSame('www.example.com', $model->getLockToDomain());
         self::assertSame('We build websites!', $model->getDescription());
     }
 

--- a/Tests/Functional/Domain/Repository/FrontendUserRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/FrontendUserRepositoryTest.php
@@ -72,7 +72,6 @@ final class FrontendUserRepositoryTest extends FunctionalTestCase
         self::assertSame('+49 1111 1233456-78', $model->getTelephone());
         self::assertSame('+49 1111 1233456-79', $model->getFax());
         self::assertSame('max@example.com', $model->getEmail());
-        self::assertSame('example.com', $model->getLockToDomain());
         self::assertSame('Head of fur', $model->getTitle());
         self::assertSame('01234', $model->getZip());
         self::assertSame('Kattingen', $model->getCity());

--- a/Tests/Functional/Domain/Repository/FrontendUserWithCountryRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/FrontendUserWithCountryRepositoryTest.php
@@ -75,7 +75,6 @@ final class FrontendUserWithCountryRepositoryTest extends FunctionalTestCase
         self::assertSame('+49 1111 1233456-78', $model->getTelephone());
         self::assertSame('+49 1111 1233456-79', $model->getFax());
         self::assertSame('max@example.com', $model->getEmail());
-        self::assertSame('example.com', $model->getLockToDomain());
         self::assertSame('Head of fur', $model->getTitle());
         self::assertSame('01234', $model->getZip());
         self::assertSame('Kattingen', $model->getCity());

--- a/Tests/Unit/Domain/Model/FrontendUserGroupTest.php
+++ b/Tests/Unit/Domain/Model/FrontendUserGroupTest.php
@@ -72,28 +72,6 @@ final class FrontendUserGroupTest extends UnitTestCase
     /**
      * @test
      */
-    public function getLockToDomainInitiallyReturnsEmptyString(): void
-    {
-        $result = $this->subject->getLockToDomain();
-
-        self::assertSame('', $result);
-    }
-
-    /**
-     * @test
-     */
-    public function setLockToDomainSetsLockToDomain(): void
-    {
-        $lockToDomain = 'example.com';
-
-        $this->subject->setLockToDomain($lockToDomain);
-
-        self::assertSame($lockToDomain, $this->subject->getLockToDomain());
-    }
-
-    /**
-     * @test
-     */
     public function getSubgroupInitiallyReturnsEmptyStorage(): void
     {
         $result = $this->subject->getSubgroup();

--- a/Tests/Unit/Domain/Model/FrontendUserTest.php
+++ b/Tests/Unit/Domain/Model/FrontendUserTest.php
@@ -329,28 +329,6 @@ final class FrontendUserTest extends UnitTestCase
     /**
      * @test
      */
-    public function getLockToDomainInitiallyReturnsEmptyString(): void
-    {
-        $result = $this->subject->getLockToDomain();
-
-        self::assertSame('', $result);
-    }
-
-    /**
-     * @test
-     */
-    public function setLockToDomainSetsLockToDomain(): void
-    {
-        $lockToDomain = 'foo.bar';
-
-        $this->subject->setLockToDomain($lockToDomain);
-
-        self::assertSame($lockToDomain, $this->subject->getLockToDomain());
-    }
-
-    /**
-     * @test
-     */
     public function getTitleInitiallyReturnsEmptyString(): void
     {
         $result = $this->subject->getTitle();


### PR DESCRIPTION
This property was be removed in TYPO3 11LTS.

Fixes #121