### PR TITLE
[TASK] Make the required system extension versions consistent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
 		"sjbr/static-info-tables": "^6.9.6 || ^11.5.2",
 		"squizlabs/php_codesniffer": "^3.7.1",
 		"symfony/yaml": "^4.4.37 || ^5.3.14 || ^6.0.2",
-		"typo3/cms-extensionmanager": "^10.4 || ^11.5",
+		"typo3/cms-extensionmanager": "^10.4.11 || ^11.5.2",
 		"typo3/coding-standards": "^0.5.5",
 		"typo3/testing-framework": "^6.16.6"
 	},


### PR DESCRIPTION
As it is not possible to install system extensions in different versions (e.g., extbase 10.4.7 together with fluid 10.4.11), we should require the same versions for all system extensions for consistency.