### PR TITLE
[BUGFIX] Add a `symfony/routing` dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
 		"seld/jsonlint": "^1.9.0",
 		"sjbr/static-info-tables": "^6.9.6 || ^11.5.2",
 		"squizlabs/php_codesniffer": "^3.7.1",
+		"symfony/routing": "^5.4.11 || ^6.1.3",
 		"symfony/yaml": "^4.4.37 || ^5.3.14 || ^6.0.2",
 		"typo3/cms-extensionmanager": "^10.4.11 || ^11.5.2",
 		"typo3/coding-standards": "^0.5.5",


### PR DESCRIPTION
This avoids warnings with PHP 8.1/8.2 with packages versions that are too low.