### PR TITLE
[TASK] Do not run the PHP 8.2 tests with the lowest dependencies (#1210)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,9 +169,6 @@ jobs:
           - typo3-version: "^11.5"
             php-version: "8.2"
             composer-dependencies: highest
-          - typo3-version: "^11.5"
-            php-version: "8.2"
-            composer-dependencies: lowest
   functional-tests:
     name: "Functional tests"
     runs-on: ubuntu-22.04
@@ -272,6 +269,3 @@ jobs:
           - typo3-version: "^11.5"
             php-version: "8.2"
             composer-dependencies: highest
-          - typo3-version: "^11.5"
-            php-version: "8.2"
-            composer-dependencies: lowest


### PR DESCRIPTION
We need some bug fixes in newer versions of the dependencies to have the PHP 8.2 build warning-free.