### PR TITLE
[TASK] Stop running functional tests on PHP 8.1 with the lowest deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,8 +264,5 @@ jobs:
             php-version: "8.1"
             composer-dependencies: highest
           - typo3-version: "^11.5"
-            php-version: "8.1"
-            composer-dependencies: lowest
-          - typo3-version: "^11.5"
             php-version: "8.2"
             composer-dependencies: highest


### PR DESCRIPTION
With the lowest dependencies, we get too many warnings due to bugs in Symfony.