### PR TITLE
[TASK] Exclude `symfony/routing` from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,7 @@ updates:
         versions: [ ">= 3.4.0" ]
       - dependency-name: "phpunit/phpunit"
         versions: [ ">= 9" ]
+      - dependency-name: "symfony/routing"
       - dependency-name: "symfony/yaml"
       - dependency-name: "typo3/cms-*"
     versioning-strategy: "increase"


### PR DESCRIPTION
Dependabot cannot handle multi-version dependencies.

Fixes #203