### PR TITLE
[BUGFIX] Block Dependabot updates for multi-version dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,7 @@ updates:
         versions: [ ">= 3.4.0" ]
       - dependency-name: "phpunit/phpunit"
         versions: [ ">= 9" ]
+      - dependency-name: "sjbr/static-info-tables"
       - dependency-name: "symfony/routing"
       - dependency-name: "symfony/yaml"
       - dependency-name: "typo3/cms-*"


### PR DESCRIPTION
Dependabot will happily mangle them (like e.g., in #210).