### PR TITLE
[TASK] Limit the runtime of the CI jobs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -10,6 +10,8 @@ jobs:
 
     if: ${{ github.actor == 'dependabot[bot]' }}
 
+    timeout-minutes: 1
+
     steps:
       - uses: peter-evans/enable-pull-request-automerge@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
   php-lint:
     name: "PHP linter"
     runs-on: ubuntu-22.04
+    timeout-minutes: 1
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3
@@ -39,6 +40,7 @@ jobs:
   code-quality:
     name: "Code quality checks"
     runs-on: ubuntu-22.04
+    timeout-minutes: 1
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3
@@ -80,6 +82,7 @@ jobs:
   xliff-lint:
     name: "Xliff linter"
     runs-on: ubuntu-22.04
+    timeout-minutes: 1
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3
@@ -89,6 +92,7 @@ jobs:
     name: "Unit tests"
     runs-on: ubuntu-22.04
     needs: php-lint
+    timeout-minutes: 1
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3
@@ -174,6 +178,7 @@ jobs:
     name: "Functional tests"
     runs-on: ubuntu-22.04
     needs: php-lint
+    timeout-minutes: 2
     env:
       DB_DATABASE: typo3
       DB_USER: root

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -9,6 +9,7 @@ jobs:
   code-coverage:
     name: "Calculate code coverage"
     runs-on: ubuntu-22.04
+    timeout-minutes: 3
     env:
       DB_DATABASE: typo3
       DB_USER: root

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-22.04
+
+    timeout-minutes: 3
+
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3


### PR DESCRIPTION
This keeps stuck jobs from unnecessarily hogging CI resources.