### PR TITLE
[TASK] Drop the property mapping for the removed `lockToDomain` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Deprecated
 
 ### Removed
+- Drop the property mapping for the removed `lockToDomain` property (#325)
 
 ### Fixed
 

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -7,7 +7,6 @@ return [
         'tableName' => 'fe_users',
         'properties' => [
             'userGroup' => ['fieldName' => 'usergroup'],
-            'lockToDomain' => ['fieldName' => 'lockToDomain'],
             'lastLogin' => ['fieldName' => 'lastlogin'],
         ],
     ],
@@ -15,14 +14,10 @@ return [
         'tableName' => 'fe_users',
         'properties' => [
             'userGroup' => ['fieldName' => 'usergroup'],
-            'lockToDomain' => ['fieldName' => 'lockToDomain'],
             'lastLogin' => ['fieldName' => 'lastlogin'],
         ],
     ],
     OliverKlee\FeUserExtraFields\Domain\Model\FrontendUserGroup::class => [
         'tableName' => 'fe_groups',
-        'properties' => [
-            'lockToDomain' => ['fieldName' => 'lockToDomain'],
-        ],
     ],
 ];


### PR DESCRIPTION
This field was removed some time ago, but I forgot to also remove the mapping configuration for it.