### PR TITLE
[TASK] Drop the `jangregor/phpstan-prophecy` Composer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
 		"doctrine/dbal": "^2.13.9",
 		"ergebnis/composer-normalize": "^2.19.0",
 		"friendsofphp/php-cs-fixer": "^3.4.0",
-		"jangregor/phpstan-prophecy": "^1.0.0",
 		"php-coveralls/php-coveralls": "^2.5.3",
 		"phpstan/extension-installer": "^1.3.0",
 		"phpstan/phpstan": "^1.10.14",


### PR DESCRIPTION
We are not using Prophecy anymore and hence do not need PHPStan to have additional configuration for this.

Fixes #271