### PR TITLE
[TASK] Allow higher versions of the dev dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,17 +15,11 @@ updates:
     allow:
       - dependency-type: "development"
     ignore:
-      - dependency-name: "ergebnis/composer-normalize"
-        versions: [ ">= 2.19.0" ]
-      - dependency-name: "friendsofphp/php-cs-fixer"
-        versions: [ ">= 3.4.0" ]
       - dependency-name: "phpunit/phpunit"
         versions: [ ">= 9" ]
       - dependency-name: "sjbr/static-info-tables"
       - dependency-name: "symfony/routing"
       - dependency-name: "symfony/yaml"
       - dependency-name: "typo3/cms-*"
-      - dependency-name: "typo3/coding-standards"
-        versions: [ ">= 0.7.0" ]
     versioning-strategy: "increase"
     milestone: 11

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
 		"symfony/routing": "^5.4.26 || ^6.3.5",
 		"symfony/yaml": "^5.4.30 || ^6.3.7",
 		"typo3/cms-extensionmanager": "^11.5.4",
-		"typo3/coding-standards": "~0.6.1",
+		"typo3/coding-standards": "^0.6.1",
 		"typo3/testing-framework": "^6.16.9"
 	},
 	"replace": {


### PR DESCRIPTION
Now that we've dropped support for PHP 7.2/7.3 and TYPO3 10LTS, we can have higher versions of some development dependencies.