### PR TITLE
[TASK] Drop sjbr/static-info-tables from the Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,6 @@ updates:
         versions: [ ">= 3.9.6" ]
       - dependency-name: "phpunit/phpunit"
         versions: [ ">= 9" ]
-      - dependency-name: "sjbr/static-info-tables"
       - dependency-name: "symfony/routing"
       - dependency-name: "symfony/yaml"
       - dependency-name: "typo3/cms-*"


### PR DESCRIPTION
We are not using that package anymore.