### PR TITLE
[TASK] Drop PHP copy paste detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,6 @@ jobs:
         command:
           - "composer:normalize"
           - "json:lint"
-          - "php:copypaste"
           - "php:cs-fixer"
           - "php:sniff"
           - "php:stan"

--- a/composer.json
+++ b/composer.json
@@ -111,13 +111,11 @@
 		],
 		"ci:json:lint": "find . ! -path '*.Build/*' -name '*.json' | xargs -r php .Build/vendor/bin/jsonlint -q",
 		"ci:php": [
-			"@ci:php:copypaste",
 			"@ci:php:cs-fixer",
 			"@ci:php:lint",
 			"@ci:php:sniff",
 			"@ci:php:stan"
 		],
-		"ci:php:copypaste": "tools/phpcpd Classes",
 		"ci:php:cs-fixer": "php-cs-fixer fix --config .php-cs-fixer.php -v --dry-run --diff",
 		"ci:php:lint": "find .*.php *.php Classes Configuration Tests -name '*.php' -print0 | xargs -r -0 -n 1 -P 4 php -l",
 		"ci:php:sniff": "phpcs Classes Configuration Tests",
@@ -125,7 +123,6 @@
 		"ci:static": [
 			"@ci:composer:normalize",
 			"@ci:json:lint",
-			"@ci:php:copypaste",
 			"@ci:php:cs-fixer",
 			"@ci:php:lint",
 			"@ci:php:sniff",
@@ -191,7 +188,6 @@
 		"ci:dynamic": "Runs all PHPUnit tests (unit and functional).",
 		"ci:json:lint": "Lints the JSON files.",
 		"ci:php": "Runs all static checks for the PHP files.",
-		"ci:php:copypaste": "Checks for copy'n'pasted PHP code.",
 		"ci:php:cs-fixer": "Checks the code style with the PHP Coding Standards Fixer (PHP-CS-Fixer).",
 		"ci:php:lint": "Lints the PHP files for syntax errors.",
 		"ci:php:sniff": "Checks the code style with PHP_CodeSniffer (PHPCS).",

--- a/phive.xml
+++ b/phive.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
   <phar name="phpcov" version="^8.2.1" installed="8.2.1" location="./tools/phpcov" copy="false"/>
-  <phar name="phpcpd" version="^6.0.3" installed="6.0.3" location="./tools/phpcpd" copy="false"/>
 </phive>


### PR DESCRIPTION
For this project, copy paste detection does not provide any benefit.

Also, removing this CI job speeds up the CI builds a bit.