### PR TITLE
[TASK] Drop obsolete item from the Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,6 @@ updates:
     allow:
       - dependency-type: "development"
     ignore:
-      - dependency-name: "doctrine/dbal"
       - dependency-name: "ergebnis/composer-normalize"
         versions: [ ">= 2.29.0" ]
       - dependency-name: "phpunit/phpunit"


### PR DESCRIPTION
We don't have `doctrine/dbal` as a dependency anymore and hence do not need a Dependabot configuration for it.