### PR TITLE
[CLEANUP] Reduce redundancies in the PHPStan configuration

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,10 +17,5 @@ parameters:
     - Configuration
     - Tests
 
-  scanDirectories:
-    - Classes
-    - Configuration
-    - Tests
-
   # Allow instanceof checks, particularly in tests
   checkAlwaysTrueCheckTypeFunctionCall: false


### PR DESCRIPTION
Directories configured via `paths` already allows PHPStan to discover the symbols in the code located there. So there is no need to add these directories again via `scanDirectories`.

https://phpstan.org/user-guide/discovering-symbols#third-party-code-outside-of-composer-dependencies