### PR TITLE
[CLEANUP] Use specific PHPStan error code in the annotations

### DIFF
--- a/Tests/Functional/Domain/Repository/FrontendUserGroupRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/FrontendUserGroupRepositoryTest.php
@@ -101,7 +101,7 @@ final class FrontendUserGroupRepositoryTest extends FunctionalTestCase
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/UserGroupWithAllScalarData.csv');
 
-        // @phpstan-ignore-next-line We are explicitly testing with a contract-violating value.
+        // @phpstan-ignore argument.type (We are explicitly testing with a contract-violating value.)
         $models = $this->subject->findByUids([1, '\'"--ab']);
 
         self::assertCount(1, $models);

--- a/Tests/Unit/Domain/Model/FrontendUserGroupTest.php
+++ b/Tests/Unit/Domain/Model/FrontendUserGroupTest.php
@@ -29,8 +29,8 @@ final class FrontendUserGroupTest extends UnitTestCase
 
     protected function tearDown(): void
     {
-        // @phpstan-ignore-next-line We know that the necessary array keys exist.
-        unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][FrontendUserGroup::class]);
+        // @phpstan-ignore offsetAccess.nonOffsetAccessible, offsetAccess.nonOffsetAccessible
+        unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects']);
         MakeInstanceCacheFlusher::flushMakeInstanceCache();
         parent::tearDown();
     }
@@ -48,9 +48,10 @@ final class FrontendUserGroupTest extends UnitTestCase
      */
     public function canBeSubclassed(): void
     {
-        // @phpstan-ignore-next-line We know that the necessary array keys exist.
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][FrontendUserGroup::class]
-            = ['className' => XclassFrontendUserGroup::class];
+        // @phpstan-ignore offsetAccess.nonOffsetAccessible, offsetAccess.nonOffsetAccessible
+        $xclassConfiguration = &$GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'];
+        self::assertIsArray($xclassConfiguration);
+        $xclassConfiguration[FrontendUserGroup::class] = ['className' => XclassFrontendUserGroup::class];
 
         $instance = GeneralUtility::makeInstance(FrontendUserGroup::class);
 

--- a/Tests/Unit/Domain/Model/FrontendUserTest.php
+++ b/Tests/Unit/Domain/Model/FrontendUserTest.php
@@ -31,8 +31,8 @@ final class FrontendUserTest extends UnitTestCase
 
     protected function tearDown(): void
     {
-        // @phpstan-ignore-next-line We know that the necessary array keys exist.
-        unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][FrontendUser::class]);
+        // @phpstan-ignore offsetAccess.nonOffsetAccessible, offsetAccess.nonOffsetAccessible
+        unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects']);
         MakeInstanceCacheFlusher::flushMakeInstanceCache();
         parent::tearDown();
     }
@@ -50,8 +50,10 @@ final class FrontendUserTest extends UnitTestCase
      */
     public function canBeSubclassed(): void
     {
-        // @phpstan-ignore-next-line We know that the necessary array keys exist.
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][FrontendUser::class] = ['className' => XclassFrontendUser::class];
+        // @phpstan-ignore offsetAccess.nonOffsetAccessible, offsetAccess.nonOffsetAccessible
+        $xclassConfiguration = &$GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'];
+        self::assertIsArray($xclassConfiguration);
+        $xclassConfiguration[FrontendUser::class] = ['className' => XclassFrontendUser::class];
 
         $instance = GeneralUtility::makeInstance(FrontendUser::class);
 

--- a/Tests/Unit/Domain/Repository/FrontendUserGroupRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/FrontendUserGroupRepositoryTest.php
@@ -24,7 +24,7 @@ final class FrontendUserGroupRepositoryTest extends UnitTestCase
 
         if (\interface_exists(ObjectManagerInterface::class)) {
             $objectManagerStub = $this->createStub(ObjectManagerInterface::class);
-            // @phpstan-ignore-next-line This line is 11LTS-specific, but we're running PHPStan on TYPO3 12.
+            // @phpstan-ignore arguments.count (This line is 11LTS-specific, but we're running PHPStan on TYPO3 12.)
             $this->subject = new FrontendUserGroupRepository($objectManagerStub);
         } else {
             $this->subject = new FrontendUserGroupRepository();

--- a/Tests/Unit/Domain/Repository/FrontendUserRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/FrontendUserRepositoryTest.php
@@ -24,7 +24,7 @@ final class FrontendUserRepositoryTest extends UnitTestCase
 
         if (\interface_exists(ObjectManagerInterface::class)) {
             $objectManagerStub = $this->createStub(ObjectManagerInterface::class);
-            // @phpstan-ignore-next-line This line is 11LTS-specific, but we're running PHPStan on TYPO3 12.
+            // @phpstan-ignore arguments.count (This line is 11LTS-specific, but we're running PHPStan on TYPO3 12.)
             $this->subject = new FrontendUserRepository($objectManagerStub);
         } else {
             $this->subject = new FrontendUserRepository();


### PR DESCRIPTION
Also harden some array accesses in the tests.

Fixes #586