### PR TITLE
[FEATURE] Add a wrapper class for gender values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Add a wrapper class for gender values (#624)
 - Add `FrontendUser.vatIn` (VAT identification number) (#623)
 - Add `FrontendUser.privacyDateOfAcceptance` (#622)
 - Add `FrontendUser.termsDateOfAcceptance` (#620)
@@ -13,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 ### Deprecated
+- Deprecate the gender constants (#624)
 
 ### Removed
 

--- a/Classes/Domain/Model/FrontendUser.php
+++ b/Classes/Domain/Model/FrontendUser.php
@@ -19,26 +19,36 @@ class FrontendUser extends AbstractEntity
 
     /**
      * @var int
+     *
+     * @deprecated #599 will be removed in version 7.0, use the `Gender` class instead
      */
     public const GENDER_MALE = 0;
 
     /**
      * @var int
+     *
+     * @deprecated #599 will be removed in version 7.0, use the `Gender` class instead
      */
     public const GENDER_FEMALE = 1;
 
     /**
      * @var int
+     *
+     * @deprecated #599 will be removed in version 7.0, use the `Gender` class instead
      */
     public const GENDER_DIVERSE = 2;
 
     /**
      * @var int
+     *
+     * @deprecated #599 will be removed in version 7.0, use the `Gender` class instead
      */
     public const GENDER_NOT_PROVIDED = 99;
 
     /**
      * @var list<self::GENDER_*>
+     *
+     * @deprecated #599 will be removed in version 7.0, use the `Gender` class instead
      */
     public const VALID_GENDERS = [
         self::GENDER_MALE,
@@ -532,6 +542,9 @@ class FrontendUser extends AbstractEntity
         $this->fullSalutation = $fullSalutation;
     }
 
+    /**
+     * @deprecated #599 will be removed in version 7.0, use the `Gender` class instead
+     */
     public static function isValidGender(int $gender): bool
     {
         return \in_array($gender, self::VALID_GENDERS, true);

--- a/Classes/Domain/Model/Gender.php
+++ b/Classes/Domain/Model/Gender.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\FeUserExtraFields\Domain\Model;
+
+/**
+ * Adapter to allow for TYPO3-version-independent gender values.
+ */
+final class Gender
+{
+    /**
+     * @return int<0, max>
+     */
+    public static function notProvided(): int
+    {
+        return 99;
+    }
+
+    /**
+     * @return int<0, max>
+     */
+    public static function diverse(): int
+    {
+        return 2;
+    }
+
+    /**
+     * @return int<0, max>
+     */
+    public static function female(): int
+    {
+        return 1;
+    }
+
+    /**
+     * @return int<0, max>
+     */
+    public static function male(): int
+    {
+        return 0;
+    }
+
+    /**
+     * @return list<int<0, max>|null>
+     */
+    private static function definedGenders(): array
+    {
+        return [
+            self::notProvided(),
+            self::diverse(),
+            self::female(),
+            self::male(),
+        ];
+    }
+
+    public static function isValidGender(?int $gender): bool
+    {
+        return \in_array($gender, self::definedGenders(), true);
+    }
+}

--- a/Configuration/TCA/Overrides/fe_users.php
+++ b/Configuration/TCA/Overrides/fe_users.php
@@ -1,6 +1,7 @@
 <?php
 
 use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUser;
+use OliverKlee\FeUserExtraFields\Domain\Model\Gender;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
@@ -49,22 +50,22 @@ call_user_func(static function (): void {
                 'items' => [
                     [
                         'label' => $languageFile . 'gender.99',
-                        'value' => FrontendUser::GENDER_NOT_PROVIDED,
+                        'value' => Gender::notProvided(),
                     ],
                     [
                         'label' => $languageFile . 'gender.0',
-                        'value' => FrontendUser::GENDER_MALE,
+                        'value' => Gender::male(),
                     ],
                     [
                         'label' => $languageFile . 'gender.1',
-                        'value' => FrontendUser::GENDER_FEMALE,
+                        'value' => Gender::female(),
                     ],
                     [
                         'label' => $languageFile . 'gender.2',
-                        'value' => FrontendUser::GENDER_DIVERSE,
+                        'value' => Gender::diverse(),
                     ],
                 ],
-                'default' => FrontendUser::GENDER_NOT_PROVIDED,
+                'default' => Gender::notProvided(),
             ],
         ],
         'date_of_birth' => [
@@ -210,19 +211,19 @@ call_user_func(static function (): void {
                         'items' => [
                             [
                                 $languageFile . 'gender.99',
-                                FrontendUser::GENDER_NOT_PROVIDED,
+                                Gender::notProvided(),
                             ],
                             [
                                 $languageFile . 'gender.0',
-                                FrontendUser::GENDER_MALE,
+                                Gender::male(),
                             ],
                             [
                                 $languageFile . 'gender.1',
-                                FrontendUser::GENDER_FEMALE,
+                                Gender::female(),
                             ],
                             [
                                 $languageFile . 'gender.2',
-                                FrontendUser::GENDER_DIVERSE,
+                                Gender::diverse(),
                             ],
                         ],
                     ],

--- a/Tests/Functional/Domain/Repository/FrontendUserRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/FrontendUserRepositoryTest.php
@@ -6,6 +6,7 @@ namespace OliverKlee\FeUserExtraFields\Tests\Functional\Domain\Repository;
 
 use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUser;
 use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUserGroup;
+use OliverKlee\FeUserExtraFields\Domain\Model\Gender;
 use OliverKlee\FeUserExtraFields\Domain\Repository\FrontendUserRepository;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
@@ -78,7 +79,7 @@ final class FrontendUserRepositoryTest extends FunctionalTestCase
         self::assertEquals(new \DateTime('2024-05-18T02:40'), $model->getTermsDateOfAcceptance());
         self::assertSame('NRW', $model->getZone());
         self::assertSame('Welcome, Max MM!', $model->getFullSalutation());
-        self::assertSame(FrontendUser::GENDER_DIVERSE, $model->getGender());
+        self::assertSame(Gender::diverse(), $model->getGender());
         self::assertEquals(new \DateTime('2022-04-02T00:00'), $model->getDateOfBirth());
         self::assertSame(FrontendUser::STATUS_JOB_SEEKING_FULL_TIME, $model->getStatus());
         self::assertSame('Here we go!', $model->getComments());

--- a/Tests/Unit/Domain/Model/GenderTest.php
+++ b/Tests/Unit/Domain/Model/GenderTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\FeUserExtraFields\Tests\Unit\Domain\Model;
+
+use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUser;
+use OliverKlee\FeUserExtraFields\Domain\Model\Gender;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * @covers OliverKlee\FeUserExtraFields\Domain\Model\Gender
+ */
+final class GenderTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function maleReturnsValueForMale(): void
+    {
+        self::assertSame(FrontendUser::GENDER_MALE, Gender::male());
+    }
+
+    /**
+     * @test
+     */
+    public function femaleReturnsValueForFemale(): void
+    {
+        self::assertSame(FrontendUser::GENDER_FEMALE, Gender::female());
+    }
+
+    /**
+     * @test
+     */
+    public function diverseReturnsValueForDiverse(): void
+    {
+        self::assertSame(FrontendUser::GENDER_DIVERSE, Gender::diverse());
+    }
+
+    /**
+     * @test
+     */
+    public function notProvidedReturnsValueForNotProvided(): void
+    {
+        self::assertSame(FrontendUser::GENDER_NOT_PROVIDED, Gender::notProvided());
+    }
+
+    /**
+     * @return array<non-empty-string, array{0: int|null}>
+     */
+    public static function validGenderDataProvider(): array
+    {
+        return [
+            'not provided' => [Gender::notProvided()],
+            'diverse' => [Gender::diverse()],
+            'female' => [Gender::female()],
+            'male' => [Gender::male()],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider validGenderDataProvider
+     */
+    public function allExistingGendersAreValid(?int $gender): void
+    {
+        self::assertTrue(Gender::isValidGender($gender));
+    }
+
+    /**
+     * @return array<non-empty-string, array{0: int}>
+     */
+    public static function invalidGenderDataProvider(): array
+    {
+        return [
+            'negative' => [-1],
+            'too large' => [100],
+            'unassigned in the middle' => [50],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider invalidGenderDataProvider
+     */
+    public function invalidGenderValuesAreInvalid(int $gender): void
+    {
+        self::assertFalse(Gender::isValidGender($gender));
+    }
+}


### PR DESCRIPTION
For TYPO3 V13, the gender values will change. So we need to be able to make these values TYPO3-version-specific later.

Also deprecate the gender constants.

Fixes #588