### PR TITLE
[TASK] Allow `instanceOf` checks in a test in a different way

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,9 +17,6 @@ parameters:
     - Configuration
     - Tests
 
-  # Allow instanceof checks, particularly in tests
-  checkAlwaysTrueCheckTypeFunctionCall: false
-
   # Stricter checks
   checkBenevolentUnionTypes: true
   checkImplicitMixed: true
@@ -28,3 +25,8 @@ parameters:
   reportAlwaysTrueInLastCondition: true
   reportAnyTypeWideningInVarTag: true
   reportPossiblyNonexistentConstantArrayOffset: true
+
+  ignoreErrors:
+    -
+      message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) .* will always evaluate to#'
+      path: 'Tests/'


### PR DESCRIPTION
This removes one obstacle for upgrading to PHPStan 2.

Fixes #737