### PR TITLE
[CLEANUP] Use only booleans for `exclude` in TCA

### DIFF
--- a/Configuration/TCA/Overrides/fe_users.php
+++ b/Configuration/TCA/Overrides/fe_users.php
@@ -32,7 +32,6 @@ call_user_func(static function (): void {
             ],
         ],
         'full_salutation' => [
-            'exclude' => 0,
             'label' => $languageFile . 'full_salutation',
             'config' => [
                 'type' => 'input',


### PR DESCRIPTION
Fixes #679