### PR TITLE
[CLEANUP] Do not quote numeric default values in `ext_tables.sql`

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -4,14 +4,14 @@
 CREATE TABLE fe_users
 (
 	full_salutation            varchar(255) DEFAULT '' NOT NULL,
-	gender                     tinyint(2) unsigned DEFAULT '99' NOT NULL,
-	date_of_birth              int(11) DEFAULT '0' NOT NULL,
+	gender                     tinyint(2) unsigned DEFAULT 99 NOT NULL,
+	date_of_birth              int(11) DEFAULT 0 NOT NULL,
 	zone                       varchar(45)  DEFAULT '' NOT NULL,
-	privacy                    tinyint(1) unsigned DEFAULT '0' NOT NULL,
-	privacy_date_of_acceptance int(11) unsigned DEFAULT '0' NOT NULL,
-	terms_acknowledged         tinyint(1) unsigned DEFAULT '0' NOT NULL,
-	terms_date_of_acceptance   int(11) unsigned DEFAULT '0' NOT NULL,
-	status                     tinyint(1) unsigned DEFAULT '0' NOT NULL,
+	privacy                    tinyint(1) unsigned DEFAULT 0 NOT NULL,
+	privacy_date_of_acceptance int(11) unsigned DEFAULT 0 NOT NULL,
+	terms_acknowledged         tinyint(1) unsigned DEFAULT 0 NOT NULL,
+	terms_date_of_acceptance   int(11) unsigned DEFAULT 0 NOT NULL,
+	status                     tinyint(1) unsigned DEFAULT 0 NOT NULL,
 	comments                   text,
 	department                 varchar(128) DEFAULT '' NOT NULL,
 	vat_in                     varchar(15)  DEFAULT '' NOT NULL


### PR DESCRIPTION
For numeric columns, there is no point in string-quoting the default value.

Fixes #878