### PR TITLE
[TASK] Move Dependabot PRs to the 6.7.0 milestone

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    milestone: 33
+    milestone: 37
 
   - package-ecosystem: "composer"
     directory: "/"
@@ -25,4 +25,4 @@ updates:
       - dependency-name: "typo3/coding-standards"
         versions: [ ">= 0.7.0" ]
     versioning-strategy: "increase"
-    milestone: 33
+    milestone: 37


### PR DESCRIPTION
We'll skip the 6.6.1 release.