### PR TITLE
[TASK] Require the latest TYPO3 security release for 12LTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Require the latest TYPO3 12LTS security release (#896)
+
 ### Deprecated
 
 ### Removed

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
 	},
 	"require": {
 		"php": "^7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-		"typo3/cms-core": "^11.5.41 || ^12.4.31",
-		"typo3/cms-extbase": "^11.5.41 || ^12.4.31"
+		"typo3/cms-core": "^11.5.41 || ^12.4.41",
+		"typo3/cms-extbase": "^11.5.41 || ^12.4.41"
 	},
 	"require-dev": {
 		"ergebnis/composer-normalize": "2.48.2",


### PR DESCRIPTION
This only affects installations using TYPO3 12LTS. Installations on TYPO3 11LTS are not affected.

Fixes #838
