### PR TITLE
[TASK] Update the development dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,24 +27,24 @@
 	},
 	"require-dev": {
 		"ergebnis/composer-normalize": "2.50.0",
-		"friendsofphp/php-cs-fixer": "3.94.1",
+		"friendsofphp/php-cs-fixer": "3.94.2",
 		"phpstan/extension-installer": "1.4.3",
-		"phpstan/phpstan": "1.12.28",
+		"phpstan/phpstan": "1.12.32",
 		"phpstan/phpstan-phpunit": "1.4.2",
 		"phpstan/phpstan-strict-rules": "1.6.2",
 		"phpunit/phpunit": "9.6.34",
 		"rector/type-perfect": "1.0.0",
-		"saschaegerer/phpstan-typo3": "1.10.2 || 2.1.1",
+		"saschaegerer/phpstan-typo3": "1.10.2",
 		"squizlabs/php_codesniffer": "4.0.1",
-		"ssch/typo3-rector": "2.15.1",
+		"ssch/typo3-rector": "2.15.2",
 		"ssch/typo3-rector-testing-framework": "2.0.1",
-		"symfony/console": "5.4.47 || 6.4.25 || 7.3.3",
-		"symfony/routing": "5.4.48 || 6.4.24 || 7.3.2",
-		"symfony/translation": "5.4.45 || 6.4.24 || 7.3.3",
-		"symfony/yaml": "5.4.45 || 6.4.25 || 7.3.3",
+		"symfony/console": "5.4.47 || 6.4.32 || 7.4.4",
+		"symfony/routing": "5.4.48 || 6.4.32 || 7.4.4",
+		"symfony/translation": "5.4.45 || 6.4.32 || 7.4.4",
+		"symfony/yaml": "5.4.45 || 6.4.30 || 7.4.1",
 		"typo3/coding-standards": "0.6.1",
 		"typo3/testing-framework": "7.1.1",
-		"webmozart/assert": "^1.12.1"
+		"webmozart/assert": "^1.12.1 || ^2.1.5"
 	},
 	"replace": {
 		"typo3-ter/feuserextrafields": "self.version"


### PR DESCRIPTION
Also drop a version of `saschaegerer/phpstan-typo3` that does
not make sense with PHPStan 1 (which we're currently using).