### PR TITLE
[TASK] Reduce the PHP_CodeSniffer ruleset

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,123 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ruleset name="phpList Coding Standard">
-    <description>
-        This standard requires PHP_CodeSniffer >= 3.5.3.
-    </description>
-
+<ruleset name="oliverklee.de coding standard">
     <arg name="colors"/>
     <arg name="extensions" value="php"/>
 
-    <!--The complete PSR-12 rule set-->
-    <rule ref="PSR12"/>
-
-    <!-- Arrays -->
-    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
-    <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
-
-    <!-- Classes -->
-    <rule ref="Generic.Classes.DuplicateClassName"/>
-    <rule ref="PSR1.Classes.ClassDeclaration">
-        <exclude-pattern>Tests/Acceptance/_support/</exclude-pattern>
-    </rule>
-    <rule ref="Squiz.Classes.ClassFileName"/>
-    <rule ref="Squiz.Classes.LowercaseClassKeywords"/>
-    <rule ref="Squiz.Classes.SelfMemberReference"/>
-
-    <!-- Code analysis -->
-    <rule ref="Generic.CodeAnalysis.AssignmentInCondition"/>
-    <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
-    <rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop"/>
-    <rule ref="Generic.CodeAnalysis.ForLoopWithTestFunctionCall"/>
-    <rule ref="Generic.CodeAnalysis.JumbledIncrementer"/>
-    <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>
-    <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
-    <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
-
-    <!-- Commenting -->
-    <rule ref="Generic.Commenting.Fixme"/>
-    <rule ref="Generic.Commenting.Todo"/>
-    <rule ref="PEAR.Commenting.InlineComment"/>
-    <rule ref="Squiz.Commenting.DocCommentAlignment"/>
-    <rule ref="Squiz.Commenting.EmptyCatchComment"/>
-    <rule ref="Squiz.Commenting.FunctionCommentThrowTag"/>
-    <rule ref="Squiz.Commenting.PostStatementComment"/>
-
-    <!-- Control structures -->
-    <rule ref="PEAR.ControlStructures.ControlSignature"/>
-
-    <!-- Files -->
     <rule ref="Generic.Files.LineLength">
-        <exclude-pattern>Configuration/TCA/</exclude-pattern>
-    </rule>
-    <rule ref="Generic.Files.OneClassPerFile"/>
-    <rule ref="Generic.Files.OneInterfacePerFile"/>
-    <rule ref="Generic.Files.OneObjectStructurePerFile"/>
-    <rule ref="Zend.Files.ClosingTag"/>
-
-    <!-- Formatting -->
-    <rule ref="PEAR.Formatting.MultiLineAssignment"/>
-
-    <!-- Functions -->
-    <rule ref="Squiz.Functions.FunctionDuplicateArgument"/>
-    <rule ref="Squiz.Functions.GlobalFunction"/>
-
-    <!-- Methods -->
-    <rule ref="PSR2.Methods.MethodDeclaration.Underscore">
-        <exclude-pattern>Tests/Acceptance/</exclude-pattern>
-    </rule>
-
-    <!-- Metrics -->
-    <rule ref="Generic.Metrics.CyclomaticComplexity"/>
-    <rule ref="Generic.Metrics.NestingLevel"/>
-
-    <!-- Naming conventions -->
-    <rule ref="Generic.NamingConventions.ConstructorName"/>
-    <rule ref="PEAR.NamingConventions.ValidClassName"/>
-
-    <!-- Operators -->
-    <rule ref="Squiz.Operators.IncrementDecrementUsage"/>
-    <rule ref="Squiz.Operators.ValidLogicalOperators"/>
-
-    <!-- PHP -->
-    <rule ref="Generic.PHP.BacktickOperator"/>
-    <rule ref="Generic.PHP.CharacterBeforePHPOpeningTag"/>
-    <rule ref="Generic.PHP.DeprecatedFunctions"/>
-    <rule ref="Generic.PHP.DisallowAlternativePHPTags"/>
-    <rule ref="Generic.PHP.DisallowShortOpenTag"/>
-    <rule ref="Generic.PHP.DiscourageGoto"/>
-    <rule ref="Generic.PHP.ForbiddenFunctions"/>
-    <rule ref="Generic.PHP.NoSilencedErrors"/>
-    <rule ref="Squiz.PHP.CommentedOutCode">
         <properties>
-            <property name="maxPercentage" value="70"/>
+            <property name="lineLimit" value="120"/>
+            <property name="absoluteLineLimit" value="120"/>
         </properties>
     </rule>
-    <rule ref="Squiz.PHP.DisallowMultipleAssignments"/>
-    <rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>
-    <rule ref="Squiz.PHP.DiscouragedFunctions"/>
-    <rule ref="Squiz.PHP.Eval"/>
-    <rule ref="Squiz.PHP.GlobalKeyword"/>
     <rule ref="Squiz.PHP.Heredoc"/>
-    <rule ref="Squiz.PHP.InnerFunctions"/>
-    <rule ref="Squiz.PHP.LowercasePHPFunctions"/>
-    <rule ref="Squiz.PHP.NonExecutableCode"/>
-
-    <!-- Scope -->
-    <rule ref="Squiz.Scope.MemberVarScope"/>
-    <rule ref="Squiz.Scope.StaticThisUsage"/>
-
-    <!--Strings-->
-    <rule ref="Squiz.Strings.DoubleQuoteUsage"/>
-
-    <!-- Whitespace -->
-    <rule ref="PEAR.WhiteSpace.ObjectOperatorIndent"/>
-    <rule ref="PEAR.WhiteSpace.ScopeClosingBrace"/>
-    <rule ref="Squiz.WhiteSpace.CastSpacing"/>
-    <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
-    <rule ref="Squiz.WhiteSpace.OperatorSpacing">
-        <properties>
-            <property name="ignoreNewlines" value="true" />
-        </properties>
-    </rule>
-    <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
 </ruleset>


### PR DESCRIPTION
Nowadays, PHP-CS-Fixer covers most of our code style checking needs. So we should only have those rules in the PHP_CodeSniffer configuration that are not covered by PHP-CS-Fixer.

This gets rid of the hassle of resolving rule conflicts between the two tools.

Also fix some copy'n'paste in the ruleset name.

Fixes #836