### PR TITLE
[TASK] Drop PHP 8.4 CI jobs for TYPO3 11LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,10 +184,10 @@ jobs:
             php-version: "7.4"
             composer-dependencies: highest
           - typo3-version: "^11.5"
-            php-version: "8.4"
+            php-version: "8.3"
             composer-dependencies: lowest
           - typo3-version: "^11.5"
-            php-version: "8.4"
+            php-version: "8.3"
             composer-dependencies: highest
           - typo3-version: "^12.4"
             php-version: "8.1"
@@ -273,12 +273,6 @@ jobs:
           - typo3-version: "^11.5"
             php-version: "8.3"
             composer-dependencies: highest
-#          - typo3-version: "^11.5"
-#            php-version: "8.4"
-#            composer-dependencies: lowest
-#          - typo3-version: "^11.5"
-#            php-version: "8.4"
-#            composer-dependencies: highest
           - typo3-version: "^12.4"
             php-version: "8.1"
             composer-dependencies: lowest


### PR DESCRIPTION
TYPO3 11ELTS provides PHP support only up to version 8.3: https://get.typo3.org/version/11

So there is no point running CI jobs for TYPO3 V11 with PHP 8.4 (and trying to get them to work).