### PR TITLE
[TASK] Convert the `webmozart/assert` dependency to a conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,11 +43,13 @@
 		"symfony/translation": "5.4.45 || 6.4.32 || 7.4.4",
 		"symfony/yaml": "5.4.45 || 6.4.30 || 7.4.1",
 		"typo3/coding-standards": "0.6.1 || 0.8.0",
-		"typo3/testing-framework": "7.1.1",
-		"webmozart/assert": "^1.12.1 || ^2.1.5"
+		"typo3/testing-framework": "7.1.1"
 	},
 	"replace": {
 		"typo3-ter/feuserextrafields": "self.version"
+	},
+	"conflict": {
+		"webmozart/assert": "< 1.12.1"
 	},
 	"prefer-stable": true,
 	"autoload": {


### PR DESCRIPTION
As the rationale for the dependency was to only block lower versions of that package, and we don't depend on the package, this is better modelled as a package conflict.