### PR TITLE
[BUGFIX] Drop a test that relies on ignoring invalid data

### DIFF
--- a/Classes/Domain/Repository/FrontendUserGroupRepository.php
+++ b/Classes/Domain/Repository/FrontendUserGroupRepository.php
@@ -16,7 +16,7 @@ class FrontendUserGroupRepository extends Repository implements DirectPersistInt
     use DirectPersistTrait;
 
     /**
-     * @param int[] $uids
+     * @param array<int> $uids
      *
      * @return QueryResultInterface<FrontendUserGroup>
      */

--- a/Tests/Functional/Domain/Repository/FrontendUserGroupRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/FrontendUserGroupRepositoryTest.php
@@ -107,20 +107,6 @@ final class FrontendUserGroupRepositoryTest extends FunctionalTestCase
     }
 
     #[Test]
-    public function findByUidsSilentlyIgnoresNonStringUids(): void
-    {
-        $this->importCSVDataSet(__DIR__ . '/Fixtures/UserGroupWithAllScalarData.csv');
-
-        // @phpstan-ignore argument.type (We are explicitly testing with a contract-violating value.)
-        $models = $this->subject->findByUids([1, '\'"--ab']);
-
-        self::assertCount(1, $models);
-        $firstModel = $models->current();
-        self::assertInstanceOf(FrontendUserGroup::class, $firstModel);
-        self::assertSame(1, $firstModel->getUid());
-    }
-
-    #[Test]
     public function findByUidsForForPartialMatchesReturnsOnlyTheMatches(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/UserGroupWithAllScalarData.csv');


### PR DESCRIPTION
The test breaks on Postgres.

Also improve a type annotation of the tested method.

Fixes #979